### PR TITLE
fix: Increment version

### DIFF
--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, PIPE, Popen
 from typing import Any, Dict, Iterator
 
 # PyDeployment version
-__version__ = "1.0.0"
+__version__ = "1.0.0-1"
 # Default version of PyInstaller. Can be set to a specific value if PyDeployment
 # breaks using a future version
 PYI_VERSION = None


### PR DESCRIPTION
The workflow for publishing was incorrect, so we increment the version as an easy way to restart the workflow [ci skip]