### PR TITLE
fix: Update publishing to TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python distribution to TestPyPI
+    if: !startsWith(github.ref, 'refs/tags/')
     needs:
       - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Publishing to TestPyPI will no longer occur during tag pushes [ci skip]