### PR TITLE
docs: Update release notes for v1.0.1 to use generated description in GitHub

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -3,7 +3,9 @@
 ---
 
 ## Version 1.0.1
-* Edit CLI description to reduce confusion
+* fix: Edit CLI description to reduce confusion by @zevlee in [#10](https://github.com/pydeployment/pydeployment/pull/10)
+
+**Full Changelog**: https://github.com/pydeployment/pydeployment/compare/v1.0.0...v1.0.1
 
 ## Version 1.0.0
-* Initial commit
+Initial release


### PR DESCRIPTION
[ci skip]