### PR TITLE
ci: Edit workflows

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,20 +1,6 @@
 name: CI for Linux
 
-on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'src/**'
-      - 'requirements.txt'
-      - 'requirements_pytest.txt'
-  pull_request:
-    branches:
-      - '**'
-    paths:
-      - 'src/**'
-      - 'requirements.txt'
-      - 'requirements_pytest.txt'
+on: workflow_call
 
 jobs:
   test:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,20 +1,6 @@
 name: CI for macOS
 
-on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'src/**'
-      - 'requirements.txt'
-      - 'requirements_pytest.txt'
-  pull_request:
-    branches:
-      - '**'
-    paths:
-      - 'src/**'
-      - 'requirements.txt'
-      - 'requirements_pytest.txt'
+on: workflow_call
 
 jobs:
   test:

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -1,0 +1,19 @@
+name: CI and Publish
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+    paths:
+      - 'src/**'
+
+jobs:
+  # Call CI
+  ci:
+    uses: .github/workflows/ci.yml@main
+  # Call Publish Python distribution to PyPI and TestPyPI
+  publish:
+    needs: ci
+    uses: .github/workflows/publish.yml@main

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,20 +1,6 @@
 name: CI for Windows
 
-on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'src/**'
-      - 'requirements.txt'
-      - 'requirements_pytest.txt'
-  pull_request:
-    branches:
-      - '**'
-    paths:
-      - 'src/**'
-      - 'requirements.txt'
-      - 'requirements_pytest.txt'
+on: workflow_call
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  workflow_call:
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'src/**'
+      - 'requirements.txt'
+      - 'requirements_pytest.txt'
+
+jobs:
+  # Call CI for Linux
+  ci-linux:
+    uses: .github/workflows/ci-linux.yml@main
+  # Call CI for macOS
+  ci-macos:
+    uses: .github/workflows/ci-macos.yml@main
+  # Call CI for Windows
+  ci-windows:
+    uses: .github/workflows/ci-windows.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,6 @@
 name: Publish Python distribution to PyPI and TestPyPI
 
-on:
-  push:
-    branches:
-      - 'main'
-    tags:
-      - '*'
-    paths:
-      - 'src/**'
+on: workflow_call
 
 jobs:
   build:


### PR DESCRIPTION
Edit the workflow structure. There are new files `ci.yml` and `ci-publish.yml` which call the existing workflows. As such, the previously existing workflows have been edited to be callable.

The CI workflow runs on any pull request and is also called by the CI and Publish workflow.

The CI and Publish workflow calls the CI workflow and then calls the Publish Python distribution to PyPI and TestPyPI workflow if the CI workflow is successful.