### PR TITLE
fix: Correct workflow syntax errors

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -10,10 +10,11 @@ on:
       - 'src/**'
 
 jobs:
-  # Call CI
   ci:
-    uses: .github/workflows/ci.yml@main
-  # Call Publish Python distribution to PyPI and TestPyPI
+    name: CI
+    uses: ./.github/workflows/ci.yml@main
+
   publish:
+    name: Publish Python distribution to PyPI and TestPyPI
     needs: ci
-    uses: .github/workflows/publish.yml@main
+    uses: ./.github/workflows/publish.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,14 @@ on:
       - 'requirements_pytest.txt'
 
 jobs:
-  # Call CI for Linux
   ci-linux:
-    uses: .github/workflows/ci-linux.yml@main
-  # Call CI for macOS
+    name: CI for Linux
+    uses: ./.github/workflows/ci-linux.yml@main
+
   ci-macos:
-    uses: .github/workflows/ci-macos.yml@main
-  # Call CI for Windows
+    name: CI for macOS
+    uses: ./.github/workflows/ci-macos.yml@main
+
   ci-windows:
-    uses: .github/workflows/ci-windows.yml@main
+    name: CI for Windows
+    uses: ./.github/workflows/ci-windows.yml@main


### PR DESCRIPTION
The called workflows were not referenced properly. This commit fixes the syntax errors made.