### PR TITLE
ci: Add names to workflow jobs

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   test:
+    name: Run Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   test:
+    name: Run Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -4,6 +4,7 @@ on: workflow_call
 
 jobs:
   test:
+    name: Run Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
The workflow job for unit testing simply didn't have a name. This change fixes that.