### PR TITLE
fix: Move debug statement in build class

### DIFF
--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, PIPE, Popen
 from typing import Any, Dict, Iterator
 
 # PyDeployment version
-__version__ = "1.1.2.beta0"
+__version__ = "1.1.2.beta1"
 # Default version of PyInstaller. Can be set to a specific value if PyDeployment
 # breaks using a future version
 PYI_VERSION = None

--- a/src/pydeployment/build.py
+++ b/src/pydeployment/build.py
@@ -302,8 +302,8 @@ class Build:
         except ShutilError as e:
             self.logger.error(e)
             return 1
-        return 0
         self.logger.debug(f"Package moved to {path}")
+        return 0
 
     def run(self) -> int:
         """


### PR DESCRIPTION
In the build class method `_move_app`, the debug statement to indicate that a file has been moved was placed after the return statement, rendering it useless. This commit fixes that.