### PR TITLE
fix: Add error handling for onefile user error

### DIFF
--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, PIPE, Popen
 from typing import Any, Dict, Iterator
 
 # PyDeployment version
-__version__ = "1.1.2.beta1"
+__version__ = "1.1.2.beta2"
 # Default version of PyInstaller. Can be set to a specific value if PyDeployment
 # breaks using a future version
 PYI_VERSION = None

--- a/src/pydeployment/build.py
+++ b/src/pydeployment/build.py
@@ -336,6 +336,8 @@ class Build:
             package = self.make_app()
         else:
             package = self.make_arc()
+        if isinstance(package, int):
+            return package
         # Delete build artifacts
         if not self.config.NO_CLEAN:
             self._clean()

--- a/src/pydeployment/build_linux.py
+++ b/src/pydeployment/build_linux.py
@@ -1,7 +1,7 @@
 from argparse import Namespace
 from glob import glob
 from os import makedirs, symlink
-from os.path import basename, join, relpath, splitext
+from os.path import basename, isdir, join, relpath, splitext
 from shutil import copy, make_archive, move
 from . import LINUX_DESKTOP_KEYS as KEYS
 from .build import Build
@@ -162,15 +162,21 @@ class BuildLinux(Build):
         self.logger.debug(f"Packaged app: {package}")
         return package
 
-    def make_app(self) -> str:
+    def make_app(self) -> str | int:
         """
         Make an AppImage
 
-        :return: Package filename
-        :rtype: str
+        :return: Package filename or return code
+        :rtype: str | int
         """
         self.run_pyinstaller(self.config.TARGET)
         appdir = glob(join("dist", "*"))[0]
+        if not isdir(appdir):
+            self.logger.error(
+                "PyInstaller appears to have created a one-file bundled "
+                "executable. Be sure to create a one-folder bundle instead."
+            )
+            return 1
         return self._make_app_from_appdir(appdir)
 
     def _make_arc_from_appdir(self, appdir: str) -> str:


### PR DESCRIPTION
On Linux, a user may inadvertently use onefile mode rather than onedir mode when bundling an application with PyInstaller. To address this potential issue, we add error handling to stop PyDeployment from proceeding if this case is detected.

This error handling may be added to macOS and Windows build classes some other time.

Fixes https://github.com/pydeployment/pydeployment/issues/84