### PR TITLE
feat: Add --appimage-extract-and-run option

### DIFF
--- a/docs/user-guide/advanced/archive-file.md
+++ b/docs/user-guide/advanced/archive-file.md
@@ -9,5 +9,5 @@ to package the output of PyInstaller as an archive file. On Windows, the file
 will be a ZIP file. On macOS and Linux, the file will be a tarball compressed
 with LZMA (TXZ).
 
-To use this option, set the `ARCHIVE` option to "TRUE" or any non-empty string.
+To use this option, set the `ARCHIVE` option to "True" or any non-empty string.
 Alternatively, use the `--archive` option on the command line.

--- a/docs/user-guide/advanced/custom-appimagetool.md
+++ b/docs/user-guide/advanced/custom-appimagetool.md
@@ -14,3 +14,9 @@ the file to `RUNTIME_FILE` in the environment file or `--runtime-file` on the
 command line. If you specify the value to be an empty string (i.e. `""`), then
 the latest runtime will be downloaded, which is the default behavior of the
 appimagetool binary.
+
+For compatibility purposes, you can choose to extract the appimagetool binary
+before running it. This is useful in cases where PyDeployment is run inside a
+container or on a machine where FUSE is not available. To use this option, set
+the `APPIMAGE_EXTRACT_AND_RUN` option to "True" or any non-empty string.
+Alternatively, use the `--appimage-extract-and-run` option on the command line.

--- a/docs/user-guide/build-options.md
+++ b/docs/user-guide/build-options.md
@@ -58,3 +58,4 @@ options and how they are used.
 | `--appdata` | `APPDATA` | path | Path to AppStream metadata file. File name should be in the form: The value of `ID` + `'.appdata.xml'`. | None |
 | `--appimagetool` | `APPIMAGETOOL` | path | Path to appimagetool. See [Using a Custom Appimagetool Binary](advanced/custom-appimagetool.md). | Path to PyDeployment's included appimagetool `'appimagetool-*.AppImage'`, whichever one matches the architecture of the system. |
 | `--runtime-file` | `RUNTIME_FILE` | path | Path to AppImage runtime. See [Using a Custom Appimagetool Binary](advanced/custom-appimagetool.md). | Path to PyDeployment's included AppImage runtime `'runtime-*'`, whichever one matches the architecture of the system. |
+| `--appimage-extract-and-run` | `APPIMAGE_EXTRACT_AND_RUN` | boolean | Extract appimagetool at runtime for compatibility purposes. See [Using a Custom Appimagetool Binary](advanced/custom-appimagetool.md). | `False` |

--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, PIPE, Popen
 from typing import Any, Dict, Iterator
 
 # PyDeployment version
-__version__ = "1.1.2"
+__version__ = "1.2.0.beta0"
 # Default version of PyInstaller. Can be set to a specific value if PyDeployment
 # breaks using a future version
 PYI_VERSION = None
@@ -27,8 +27,9 @@ DISPLAY_ORDER = (
     "NO_CONFIRM", "NO_CLEAN", "ARCHIVE", "FILENAME", "APPNAME", "ID",
     "VERSION", "AUTHOR", "PUBLISHER", "DESCRIPTION", "PYI_VERSION", "ICON",
     "LICENSE", "OUTDIR", "REQUIREMENTS", "VENV", "APPDATA", "APPIMAGETOOL",
-    "RUNTIME_FILE", *LINUX_DESKTOP_KEYS, "ENTI", "CERT", "KEYC", "APID",
-    "TMID", "PASS", "NSIS", "MAKENSIS", "TARGET", "PYI_ARGS"
+    "RUNTIME_FILE", "APPIMAGE_EXTRACT_AND_RUN", *LINUX_DESKTOP_KEYS, "ENTI",
+    "CERT", "KEYC", "APID", "TMID", "PASS", "NSIS", "MAKENSIS", "TARGET",
+    "PYI_ARGS"
 )
 
 

--- a/src/pydeployment/arg_parser.py
+++ b/src/pydeployment/arg_parser.py
@@ -186,6 +186,13 @@ class ArgParser(ArgumentParser):
             dest="RUNTIME_FILE",
             default=None
         )
+        self.add_argument(
+            "--appimage-extract-and-run",
+            action="store_true",
+            help="Extract appimagetool at runtime for compatibility purposes",
+            dest="APPIMAGE_EXTRACT_AND_RUN",
+            default=None
+        )
 
     def _add_macos_args(self) -> None:
         """

--- a/src/pydeployment/build_linux.py
+++ b/src/pydeployment/build_linux.py
@@ -141,22 +141,27 @@ class BuildLinux(Build):
         # Add appstream metadata
         if self.is_set("APPDATA"):
             self._add_appdata(appdir)
-        # Run appimagetool
+        # Prepare to run appimagetool
         self.logger.info("Running appimagetool")
         package = f"{self.package}.AppImage"
         appname = package.removesuffix(f"-{self.arch}.AppImage")
-        verbose = "-v" if self.config.LOG == "DEBUG" else ""
+        verbose = "-v " if self.config.LOG == "DEBUG" else ""
         if self.config.RUNTIME_FILE:
-            runtime = f"--runtime-file {self.config.RUNTIME_FILE}"
+            runtime = f"--runtime-file {self.config.RUNTIME_FILE} "
         else:
             runtime = ""
+        if self.config.APPIMAGE_EXTRACT_AND_RUN:
+            extract = "--appimage-extract-and-run "
+        else:
+            extract = ""
         # Set environment
         env = {
             "APPIMAGETOOL_APP_NAME": appname,
             "ARCH": self.arch
         }
+        # Run appimagetool
         self.run_command(
-            f"{self.config.APPIMAGETOOL} {verbose} {runtime} {appdir}",
+            f"{self.config.APPIMAGETOOL} {verbose}{runtime}{extract}{appdir}",
             self.logger.debug, env=env
         )
         self.logger.debug(f"Packaged app: {package}")


### PR DESCRIPTION
For compatiblity purposes, we add the ability to pass the --appimage-extract-and-run option to appimagetool. This is useful in the case of running inside containers or on a machine where FUSE is not available.

Fixes https://github.com/pydeployment/pydeployment/issues/92

Also add info into docs about passing --appimage-extract-and-run to appimagetool