### PR TITLE
fix: Windows and macOS onefile error handling

### DIFF
--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, PIPE, Popen
 from typing import Any, Dict, Iterator
 
 # PyDeployment version
-__version__ = "1.2.0"
+__version__ = "1.2.1.beta0"
 # Default version of PyInstaller. Can be set to a specific value if PyDeployment
 # breaks using a future version
 PYI_VERSION = None

--- a/src/pydeployment/build_macos.py
+++ b/src/pydeployment/build_macos.py
@@ -173,12 +173,12 @@ class BuildMacos(Build):
                 file.close()
         return 0
 
-    def make_app(self) -> str:
+    def make_app(self) -> str | int:
         """
         Make a DMG with an app bundle
 
-        :return: Package filename
-        :rtype: str
+        :return: Package filename or return code
+        :rtype: str | int
         """
         if self.config.MODE == "SPEC":
             basename_spec = basename(self.config.TARGET.removesuffix(".spec"))
@@ -212,7 +212,14 @@ class BuildMacos(Build):
                 ["--osx-bundle-identifier"], f"'{self.config.ID}'"
             )
             self.run_pyinstaller(self.config.TARGET)
-        appdir = glob(join("dist", "*.app"))[0]
+        try:
+            appdir = glob(join("dist", "*.app"))[0]
+        except IndexError:
+            self.logger.error(
+                "PyInstaller appears to have created a one-file bundled "
+                "executable. Be sure to create a one-folder bundle instead."
+            )
+            return 1
         return self._make_app_from_appdir(appdir)
 
     def _make_arc_from_appdir(self, appdir: str) -> str:

--- a/src/pydeployment/build_windows.py
+++ b/src/pydeployment/build_windows.py
@@ -1,6 +1,6 @@
 from argparse import Namespace
 from glob import glob
-from os.path import abspath, basename, join 
+from os.path import abspath, basename, isdir, join 
 from shutil import copy, make_archive, move
 from .build import Build
 
@@ -94,15 +94,21 @@ class BuildWindows(Build):
         self.logger.debug(f"Packaged app: {basename(package)}")
         return basename(package)
 
-    def make_app(self) -> str:
+    def make_app(self) -> str | int:
         """
         Make an installer
 
-        :return: Package filename
-        :rtype: str
+        :return: Package filename or return code
+        :rtype: str | int
         """
         self.run_pyinstaller(self.config.TARGET)
         appdir = glob(join("dist", "*"))[0]
+        if not isdir(appdir):
+            self.logger.error(
+                "PyInstaller appears to have created a one-file bundled "
+                "executable. Be sure to create a one-folder bundle instead."
+            )
+            return 1
         return self._make_app_from_appdir(appdir)
 
     def _make_arc_from_appdir(self, appdir: str) -> str:


### PR DESCRIPTION
On Windows and macOS, a user may inadvertently use onefile mode rather than onedir mode when bundling an application with PyInstaller. To address this potential issue, we add error handling to stop PyDeployment from proceeding if this case is detected.