### PR TITLE
ci: Update runner images

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        os: ['ubuntu-20.04', 'ubuntu-latest']
+        os: ['ubuntu-20.04', 'ubuntu-24.04']
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        os: ['windows-2019', 'windows-latest']
+        os: ['windows-2019', 'windows-2022']
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Explicitly make the runners use the oldest and newest supported images for testing purposes