### PR TITLE
refactor: Rearrange import statements

### DIFF
--- a/src/pydeployment/__main__.py
+++ b/src/pydeployment/__main__.py
@@ -1,5 +1,6 @@
 from platform import system
 from sys import exit
+
 from .build_config import BuildConfig
 from .build_linux import BuildLinux
 from .build_macos import BuildMacos

--- a/src/pydeployment/arg_parser.py
+++ b/src/pydeployment/arg_parser.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 from typing import Optional
+
 from . import __version__
 
 

--- a/src/pydeployment/build.py
+++ b/src/pydeployment/build.py
@@ -9,6 +9,7 @@ from shutil import Error as ShutilError, move, rmtree
 from stat import S_IWUSR
 from typing import Any, Dict, List
 from venv import create
+
 from . import DISPLAY_ORDER, PYEXE, PYI_VERSION, run_command
 from .logger import logger
 

--- a/src/pydeployment/build_config.py
+++ b/src/pydeployment/build_config.py
@@ -3,7 +3,9 @@ from os import environ
 from os.path import basename, exists
 from sys import argv
 from typing import Any, Dict
+
 from dotenv import dotenv_values
+
 from .arg_parser import ArgParser
 from .logger import logger
 

--- a/src/pydeployment/build_linux.py
+++ b/src/pydeployment/build_linux.py
@@ -3,6 +3,7 @@ from glob import glob
 from os import makedirs, symlink
 from os.path import basename, isdir, join, relpath, splitext
 from shutil import copy, make_archive, move
+
 from . import LINUX_DESKTOP_KEYS as KEYS
 from .build import Build
 

--- a/src/pydeployment/build_macos.py
+++ b/src/pydeployment/build_macos.py
@@ -4,6 +4,7 @@ from os import sep, symlink
 from os.path import basename, dirname, join
 from re import sub
 from shutil import copy, make_archive, move
+
 from .build import Build
 
 

--- a/src/pydeployment/build_windows.py
+++ b/src/pydeployment/build_windows.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 from glob import glob
 from os.path import abspath, basename, isdir, join 
 from shutil import copy, make_archive, move
+
 from .build import Build
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,9 @@
 from pydeployment import PYEXE, run_command
 from pydeployment.arg_parser import ArgParser
-from pydeployment.logger import logger as logger_
-from pydeployment.build_config import BuildConfig
 from pydeployment.build import Build
+from pydeployment.build_config import BuildConfig
 from pydeployment.build_linux import BuildLinux
 from pydeployment.build_macos import BuildMacos
 from pydeployment.build_windows import BuildWindows
+from pydeployment.logger import logger as logger_
 from pydeployment.__main__ import main as main_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,10 @@ from os.path import abspath, exists
 from pathlib import PosixPath
 from platform import system
 from typing import Iterator, Optional, Tuple
+
 from pytest import fixture, mark
 from _pytest.monkeypatch import MonkeyPatch
+
 from . import *
 
 

--- a/tests/test_arg_parser.py
+++ b/tests/test_arg_parser.py
@@ -1,6 +1,8 @@
 from argparse import Namespace as N
+
 from pytest import mark, raises
 from _pytest.capture import CaptureFixture
+
 from . import ArgParser
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,9 +4,11 @@ from os import mkdir
 from os.path import exists, join
 from platform import machine, python_compiler
 from typing import Optional, Tuple
+
 from pytest import mark, raises
 from _pytest.capture import CaptureFixture
 from _pytest.python_api import RaisesContext
+
 from . import Build
 
 

--- a/tests/test_build_config.py
+++ b/tests/test_build_config.py
@@ -1,8 +1,10 @@
 from collections.abc import Callable
 from os import environ
 from typing import Any, Dict, List, Optional, Tuple
+
 from pytest import fixture, mark
 from _pytest.monkeypatch import MonkeyPatch
+
 from . import BuildConfig
 
 

--- a/tests/test_build_linux.py
+++ b/tests/test_build_linux.py
@@ -3,7 +3,9 @@ from os.path import exists, join
 from platform import system
 from shutil import move
 from typing import Optional, Tuple
+
 from pytest import mark
+
 from . import BuildLinux
 
 linux = mark.skipif(system() != "Linux", reason="System does not match.")

--- a/tests/test_build_macos.py
+++ b/tests/test_build_macos.py
@@ -5,8 +5,10 @@ from os.path import exists, join
 from platform import system
 from shutil import move
 from typing import Optional, Tuple
+
 from pytest import mark
 from _pytest.monkeypatch import MonkeyPatch
+
 from . import BuildConfig, BuildMacos
 
 macos = mark.skipif(system() != "Darwin", reason="System does not match.")

--- a/tests/test_build_windows.py
+++ b/tests/test_build_windows.py
@@ -4,7 +4,9 @@ from os.path import exists
 from platform import system
 from shutil import move
 from typing import Optional, Tuple
+
 from pytest import mark
+
 from . import BuildWindows
 
 windows = mark.skipif(system() != "Windows", reason="System does not match.")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,4 +1,5 @@
 from logging import INFO, Logger, StreamHandler
+
 from pytest import mark
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,10 @@
-from collections.abc import Callable
 from argparse import Namespace
+from collections.abc import Callable
 from platform import system
+
 from pytest import mark
 from _pytest.monkeypatch import MonkeyPatch
+
 from . import BuildConfig
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from contextlib import nullcontext as does_not_raise
 from platform import python_compiler
 from typing import Iterator
+
 from pytest import mark, raises
 from _pytest.python_api import RaisesContext
 


### PR DESCRIPTION
**Tracking**

None

**Description**

To follow the PEP 8 guidelines for imports, we add blank lines to separate different import types from each other

Additionally, we reorder some imports to alphabetize them

**Checklist**
- [x] Commit message follows the [Conventional Commit](https://www.conventionalcommits.org/) specification
