### PR TITLE
ci: Update macos-12 to macos-13

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        os: ['macos-12', 'macos-14']
+        os: ['macos-13', 'macos-14']
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
**Tracking**

None

**Description**

The macos-12 runner image is deprecated

**Checklist**
- [x] Commit message follows the [Conventional Commit](https://www.conventionalcommits.org/) specification
