### PR TITLE
refactor: Change comment and docstring line length to be max 72 characters long in accordance with PEP 8

### DIFF
--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, PIPE, Popen
 from typing import Any, Dict, Iterator
 
 # PyDeployment version
-__version__ = "1.2.3.beta0"
+__version__ = "1.2.3.beta1"
 # Default version of PyInstaller. Can be set to a specific value if
 # PyDeployment breaks using a future version
 PYI_VERSION = None

--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Iterator
 
 # PyDeployment version
 __version__ = "1.2.3.beta0"
-# Default version of PyInstaller. Can be set to a specific value if PyDeployment
-# breaks using a future version
+# Default version of PyInstaller. Can be set to a specific value if
+# PyDeployment breaks using a future version
 PYI_VERSION = None
 # Python executable path
 if python_compiler()[:3] == "MSC":

--- a/src/pydeployment/build.py
+++ b/src/pydeployment/build.py
@@ -71,10 +71,10 @@ class Build:
 
     def validate_pyi_arg(self, opts: List[str], arg: str) -> int:
         """
-        Check if the PyInstaller arguments string contains any of the options
-        in `opts` and if not then add the first option and `arg` to the
-        end of the arguments string but before `--` as this option is used to
-        parse spec file arguments
+        Check if the PyInstaller arguments string contains any of the
+        options in `opts` and if not then add the first option and `arg`
+        to the end of the arguments string but before `--` as this
+        option is used to parse spec file arguments
 
         :param opts: Options to check
         :type opts: List[str]
@@ -133,7 +133,8 @@ class Build:
         :type cmd: str
         :param method: Logger method
         :type method: Callable[[str], None]
-        :param kwargs: Keyword arguments to pass to `run_command` function
+        :param kwargs: Keyword arguments to pass to `run_command`
+            function
         :type kwargs: Dict[str, Any]
         :return: Command output
         :rtype: str

--- a/src/pydeployment/build_config.py
+++ b/src/pydeployment/build_config.py
@@ -26,22 +26,24 @@ class BuildConfig:
 
     def _is_set(self, key: str, dict_: Dict[str, Any]) -> bool:
         """
-        Check if a key `key` in the dictionary `dict_` exists and is not empty
+        Check if a key `key` in the dictionary `dict_` exists and is
+        not empty
 
         :param key: Key to check
         :type key: str
         :param dict_: Dictionary in which to check the key
         :type dict_: Dict[str, Any]
-        :return: True if a value in the dictionary exists and is not empty
+        :return: True if a value in the dictionary exists and is not
+            empty
         :rtype: bool
         """
         return not (key not in dict_.keys() or not dict_[key])
 
     def _get_config_from_env(self) -> Dict[str, Any]:
         """
-        Get configuration from the environment file, either .env in the current
-        working directory or the path specified in the `ENV_FILE` environment
-        variable
+        Get configuration from the environment file, either .env in the
+        current working directory or the path specified in the
+        `ENV_FILE` environment variable
 
         :return: Variables from environment file
         :rtype: Dict[str, Any]
@@ -58,9 +60,9 @@ class BuildConfig:
 
     def _get_config_from_argv(self) -> Dict[str, Any]:
         """
-        Get configuration from command line arguments. Any parameters beyond
-        the `--` marker are for PyInstaller to handle and are mapped to
-        the `PYI_ARGS` key
+        Get configuration from command line arguments. Any parameters
+        beyond the `--` marker are for PyInstaller to handle and are
+        mapped to the `PYI_ARGS` key
 
         :return: Variables from command line
         :rtype: Dict[str, Any]
@@ -102,8 +104,8 @@ class BuildConfig:
 
     def _handle_target(self, config: Dict[str, Any]) -> int:
         """
-        Handle the target file by making the first argument the target and the
-        rest as PyInstaller arguments
+        Handle the target file by making the first argument the target
+        and the rest as PyInstaller arguments
 
         :param config: Configuration dictionary
         :type config: Dict[str, Any]
@@ -119,7 +121,8 @@ class BuildConfig:
 
     def _handle_defaults(self, config: Dict[str, Any]) -> int:
         """
-        Assign default values to config parameters based on the spec file
+        Assign default values to config parameters based on the spec
+        file
 
         :param config: Configuration dictionary
         :type config: Dict[str, Any]
@@ -153,8 +156,8 @@ class BuildConfig:
 
     def get_config(self, skip_validation: bool=False) -> Namespace | int:
         """
-        Get the build configuration from various sources in order of increasing
-        precedence:
+        Get the build configuration from various sources in order of
+        increasing precedence:
 
         1. The environment file
         2. Command line arguments

--- a/src/pydeployment/build_linux.py
+++ b/src/pydeployment/build_linux.py
@@ -53,8 +53,8 @@ class BuildLinux(Build):
 
     def _make_desktop_file(self, appdir: str, apprun: str) -> int:
         """
-        Make a desktop file at destination `appdir` including all environment
-        variables from `KEYS` which are set
+        Make a desktop file at destination `appdir` including all
+        environment variables from `KEYS` which are set
 
         :param appdir: Path to app directory
         :type appdir: str

--- a/src/pydeployment/build_macos.py
+++ b/src/pydeployment/build_macos.py
@@ -151,9 +151,9 @@ class BuildMacos(Build):
 
     def _sub(self, pattern: str, repl: str, path: str) -> int:
         """
-        Replace all text matching everything after `pattern` but before a
-        comma, close parenthesis, or new line with `repl` for the file at
-        `path`
+        Replace all text matching everything after `pattern` but before
+        a comma, close parenthesis, or new line with `repl` for the file
+        at `path`
 
         :param pattern: Pattern to match
         :type pattern: str
@@ -165,8 +165,8 @@ class BuildMacos(Build):
         :rtype: int
         """
         contents = open(path, "r").read()
-        # Matches string between `pattern` at the beginning and anything but a
-        # comma or close parenthesis at the end
+        # Matches string between `pattern` at the beginning and anything
+        # but a comma or close parenthesis at the end
         expr = f"(?<={pattern})(.*)(?<![,)])"
         if contents != sub(expr, repl, contents):
             with open(path, "w") as file:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,8 @@ from . import *
 @fixture(autouse=True)
 def change_test_dir(tmp_path: PosixPath, monkeypatch: MonkeyPatch) -> None:
     """
-    Fixture to change the current working directory to the test directory
+    Fixture to change the current working directory to the test
+    directory
 
     :param tmp_path: Temporary path
     :type tmp_path: pathlib.PosixPath
@@ -126,7 +127,8 @@ def config(
     :param build_config: Instance of BuildConfig for the system OS
     :type build_config: pydeployment.build_config.BuildConfig
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     :return: Test configuration
     :rtype: argparse.Namespace
     """
@@ -149,7 +151,8 @@ def config(
 @fixture
 def py() -> str:
     """
-    Fixture for the path to the python executable within a virtual environment
+    Fixture for the path to the python executable within a virtual
+    environment
 
     :return: Relative path to python executable
     :rtype: str
@@ -212,8 +215,8 @@ def build_windows(config: Namespace) -> BuildWindows:
 @fixture
 def mock_build_config() -> BuildConfig:
     """
-    Fixture for the BuildConfig class to be used for mocking the `get_config`
-    method
+    Fixture for the BuildConfig class to be used for mocking the
+    `get_config` method
 
     :return: BuildConfig class
     :rtype: pydeployment.build_config.BuildConfig

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -97,7 +97,8 @@ def test_build_calc_dir_size(
     :param build: Instance of Build
     :type build: pydeployment.build.Build
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     d, _ = tmp_file()
     assert isinstance(build.calc_dir_size(d), int)
@@ -127,7 +128,8 @@ def test_build_run_command(
     :param output: Expected output
     :type output: str
     :param exception: Expected exception context
-    :type exception: contextlib.nullcontext | _pytest.python_api.RaisesContext
+    :type exception:
+        contextlib.nullcontext | _pytest.python_api.RaisesContext
     """
     if command and python_compiler()[:3] == "MSC":
         command = f"cmd /c {command}"
@@ -147,7 +149,8 @@ def test_build_run_pyinstaller(
     :param build: Instance of Build
     :type build: pydeployment.build.Build
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     :param capfd: Capture fixture
     :type capfd: _pytest.capture.CaptureFixture
     """
@@ -170,7 +173,8 @@ def test_build_validate_paths(
     :param build: Instance of Build
     :type build: pydeployment.build.Build
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     _, p = tmp_file(path="tmp.txt")
     build.LICENSE = p
@@ -213,7 +217,8 @@ def test_build_set_up_venv(
     :param build: Instance of Build
     :type build: pydeployment.build.Build
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     :param py: Relative path to python executable
     :type py: str
     """
@@ -246,7 +251,8 @@ def test_build_move_app(
     :param build: Instance of Build
     :type build: pydeployment.build.Build
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     _, p = tmp_file(path="tmp.txt")
     assert build._move_app(p) == 0

--- a/tests/test_build_config.py
+++ b/tests/test_build_config.py
@@ -97,7 +97,8 @@ def test_build_config_validate_target(
     :param build_config: Instance of BuildConfig for the system OS
     :type build_config: pydeployment.build_config.BuildConfig
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     :param target: Target filename
     :type target: str
     :param code: Return code

--- a/tests/test_build_linux.py
+++ b/tests/test_build_linux.py
@@ -60,7 +60,8 @@ def test_build_linux_make_desktop_file(
     :param build_linux: Instance of BuildLinux
     :type build_linux: pydeployment.build.BuildLinux
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     d, p = tmp_file(path="tmp")
     build_linux._make_desktop_file(d, p)
@@ -81,7 +82,8 @@ def test_build_linux_add_appdata(
     :param build_linux: Instance of BuildLinux
     :type build_linux: pydeployment.build.BuildLinux
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     appdata = f"{build_linux.config.ID}.appdata.xml"
     d, p = tmp_file(path=appdata)
@@ -103,7 +105,8 @@ def test_build_linux_make_app_from_appdir(
     :param build_linux: Instance of BuildLinux
     :type build_linux: pydeployment.build.BuildLinux
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     d, _ = tmp_file(dir_="test", path="test")
     package = build_linux._make_app_from_appdir(d)
@@ -136,7 +139,8 @@ def test_build_linux_make_arc_from_appdir(
     :param build_linux: Instance of BuildLinux
     :type build_linux: pydeployment.build.BuildLinux
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     d, _ = tmp_file(dir_="test", path="test")
     package = build_linux._make_arc_from_appdir(d)

--- a/tests/test_build_macos.py
+++ b/tests/test_build_macos.py
@@ -43,7 +43,8 @@ def test_build_macos_notarize_app(
     :param build_config: Instance of BuildConfig for the system OS
     :type build_config: pydeployment.build_config.BuildConfig
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     _, p = tmp_file(path="tmp.py")
     build_macos._set_up_venv()
@@ -70,7 +71,8 @@ def test_build_macos_build_dmg(
     :param build_macos: Instance of BuildMacos
     :type build_macos: pydeployment.build.BuildMacos
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     # Create build directory for this test
     mkdir("build")
@@ -94,7 +96,8 @@ def test_build_macos_make_app_from_appdir(
     :param monkeypatch: Monkeypatch fixture
     :type monkeypatch: _pytest.monkeypatch.MonkeyPatch
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     with monkeypatch.context() as m:
         # Delete `CERT` attribute to skip notarization step
@@ -118,7 +121,8 @@ def test_build_macos_sub(
     :param build_macos: Instance of BuildMacos
     :type build_macos: pydeployment.build.BuildMacos
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     _, p = tmp_file(path="test.txt")
     def contents(p: str) -> str:
@@ -166,7 +170,8 @@ def test_build_macos_make_arc_from_appdir(
     :param build_macos: Instance of BuildMacos
     :type build_macos: pydeployment.build.BuildMacos
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     d, _ = tmp_file(dir_="test", path="test")
     package = build_macos._make_arc_from_appdir(d)

--- a/tests/test_build_windows.py
+++ b/tests/test_build_windows.py
@@ -49,7 +49,8 @@ def test_build_windows_make_app_from_appdir(
     :param build_windows: Instance of BuildWindows
     :type build_windows: pydeployment.build.BuildWindows
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     # Create build directory for this test
     mkdir("build")
@@ -84,7 +85,8 @@ def test_build_windows_make_arc_from_appdir(
     :param build_windows: Instance of BuildWindows
     :type build_windows: pydeployment.build.BuildWindows
     :param tmp_file: Temporary file function
-    :type tmp_file: Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
+    :type tmp_file:
+        Callable[[str, Optional[str]], Tuple[str, Optional[str]]]
     """
     d, _ = tmp_file(dir_="test", path="test")
     package = build_windows._make_arc_from_appdir(d)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,8 @@ def test_run_command(
     :param output: Expected output
     :type output: str
     :param exception: Expected exception context
-    :type exception: contextlib.nullcontext | _pytest.python_api.RaisesContext
+    :type exception:
+        contextlib.nullcontext | _pytest.python_api.RaisesContext
     """
     if command and python_compiler()[:3] == "MSC":
         command = f"cmd /c {command}"


### PR DESCRIPTION
**Tracking**

None

**Description**

Change comment and docstring line length to be max 72 characters long in accordance with PEP 8

**Checklist**
- [x] Commit message follows the [Conventional Commit](https://www.conventionalcommits.org/) specification
