### PR TITLE
Ci/disable pypi attestation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,8 @@ jobs:
           path: dist/
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false
 
   github-release:
     name: Sign the Python distribution with Sigstore and upload to GitHub Release
@@ -107,3 +109,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          attestations: false

--- a/src/pydeployment/__init__.py
+++ b/src/pydeployment/__init__.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError, PIPE, Popen
 from typing import Any, Dict, Iterator
 
 # PyDeployment version
-__version__ = "1.2.3.beta1"
+__version__ = "1.2.3.beta2"
 # Default version of PyInstaller. Can be set to a specific value if
 # PyDeployment breaks using a future version
 PYI_VERSION = None


### PR DESCRIPTION
**Tracking**

None

**Description**

Here we try to fix the PyPI upload GitHub action not working. See: https://github.com/pypa/gh-action-pypi-publish/issues/283

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
