### PR TITLE
docs: Change docs website URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: PyDeployment
-site_url: https://pydeployment.github.io/pydeployment
+site_url: https://pydeployment.github.io
 site_description: Deploy Python projects with ease.
 site_author: Zev Lee
 repo_url: https://github.com/pydeployment/pydeployment


### PR DESCRIPTION
The URL is now just pydeployment.github.io

<!-- Describe the purpose of the PR and what it accomplishes -->

**Tracking**

None

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
