### PR TITLE
build: Change homepage link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/pydeployment/pydeployment"
+"Homepage" = "https://pydeployment.github.io"
 "Bug Tracker" = "https://github.com/pydeployment/pydeployment/issues"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
The homepage should link to the documentation page, not the github project page.

<!-- Describe the purpose of the PR and what it accomplishes -->

**Tracking**
None
<!-- Link to the GitHub issue(s) that this PR addresses, if any -->

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
