### PR TITLE
ci: Update main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # Main workflow.
 #
 # Upon a push to the main branch, runs the CI test suite then the publishing
-# workflow.
+# workflow. Skips the CI test suite if publishing to PyPI.
 #
 # Run CI test suite → Build then Publish Python distribution
 #
@@ -19,11 +19,13 @@ on:
 jobs:
   ci:
     name: Run CI test suite
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
   publish:
     name: Build then Publish Python distribution
+    if: ${{ always() }}
     needs: ci
     permissions:
       contents: write


### PR DESCRIPTION
The CI test suite is no longer required to run in order to publish to PyPI. It only runs prior to publishing to TestPyPI as a final sanity check.

<!-- Describe the purpose of the PR and what it accomplishes -->

**Tracking**
None
<!-- Link to the GitHub issue(s) that this PR addresses, if any -->

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
