### PR TITLE
ci: Update ci-windows.yml

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: ['windows-2019', 'windows-2022']
+        os: ['windows-2022', 'windows-2025']
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
The `windows-2019` runner image is set to be deprecated later this year, so we shift the runner images to 2022 and 2025.

<!-- Describe the purpose of the PR and what it accomplishes -->

**Tracking**
None
<!-- Link to the GitHub issue(s) that this PR addresses, if any -->

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
