### PR TITLE
test: Fix broken import for type hinting

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 
 from pytest import mark, raises
 from _pytest.capture import CaptureFixture
-from _pytest.python_api import RaisesContext
+from _pytest.raises import RaisesExc
 
 from . import Build
 
@@ -116,7 +116,7 @@ def test_build_run_command(
         build: Build,
         command: str,
         output: str,
-        exception: does_not_raise | RaisesContext
+        exception: does_not_raise | RaisesExc
     ) -> None:
     """
     Test `run_command` method
@@ -128,8 +128,7 @@ def test_build_run_command(
     :param output: Expected output
     :type output: str
     :param exception: Expected exception context
-    :type exception: contextlib.nullcontext
-        | _pytest.python_api.RaisesContext
+    :type exception: contextlib.nullcontext | _pytest.raises.RaisesExc
     """
     if command and python_compiler()[:3] == "MSC":
         command = f"cmd /c {command}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from platform import python_compiler
 from typing import Iterator
 
 from pytest import mark, raises
-from _pytest.python_api import RaisesContext
+from _pytest.raises import RaisesExc
 
 
 @mark.order(0)
@@ -19,7 +19,7 @@ def test_run_command(
         run_cmd: Callable[[str], Iterator[str]],
         command: str,
         output: str,
-        exception: does_not_raise | RaisesContext
+        exception: does_not_raise | RaisesExc
     ) -> None:
     """
     Test `run_command` function
@@ -31,8 +31,7 @@ def test_run_command(
     :param output: Expected output
     :type output: str
     :param exception: Expected exception context
-    :type exception: contextlib.nullcontext
-        | _pytest.python_api.RaisesContext
+    :type exception: contextlib.nullcontext | _pytest.raises.RaisesExc
     """
     if command and python_compiler()[:3] == "MSC":
         command = f"cmd /c {command}"


### PR DESCRIPTION
The `RaisesContext` class is no longer accessible in the new pytest version, so we replace it.

<!-- Describe the purpose of the PR and what it accomplishes -->

**Tracking**
None
<!-- Link to the GitHub issue(s) that this PR addresses, if any -->

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
