### PR TITLE
ci: Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,13 +19,11 @@ on:
 jobs:
   ci:
     name: Run CI test suite
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
   publish:
     name: Build then Publish Python distribution
-    if: ${{ always() }}
     needs: ci
     permissions:
       contents: write


### PR DESCRIPTION
Remove conditions on running the test suite before publishing, as they do not work as intended. Supposedly, CI is skipped when pushing tags, but still works when doing a regular push. However, this causes issues when the CI fails, as the workflow still proceeds to the publish step.

<!-- Describe the purpose of the PR and what it accomplishes -->

**Tracking**
None
<!-- Link to the GitHub issue(s) that this PR addresses, if any -->

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
