### PR TITLE
chore: Update ci-macos.yml

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        os: ['macos-13', 'macos-14']
+        os: ['macos-14', 'macos-15']
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
Update the runner images as macos-13 image is deprecated

<!-- Describe the purpose of the PR and what it accomplishes -->

**Tracking**
None
<!-- Link to the GitHub issue(s) that this PR addresses, if any -->

**Checklist**
- [x] All commit messages follow the [Conventional Commit](https://www.conventionalcommits.org/) specification
